### PR TITLE
feat: Add link to soil sensors page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -26,6 +26,7 @@
                     <option value="malmesbury">Malmesbury</option>
                     <option value="karoo">Karoo</option>
                 </select>
+                <a href="/soil_sensors" class="text-gray-300 hover:text-white">Sensors</a>
             </div>
         </header>
 


### PR DESCRIPTION
This commit adds a link to the new `/soil_sensors` page on the main dashboard. This makes the new page accessible to users.